### PR TITLE
declare dependency on result and fmt in opam

### DIFF
--- a/opam
+++ b/opam
@@ -17,5 +17,5 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5"
+  "mirage-solo5" "fmt" "result"
 ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -5,7 +5,7 @@ open Topkg
 
 let () =
   let lint_deps_excluding =
-    Some [ "mirage-solo5"; "fmt"; "result" ]
+    Some [ "mirage-solo5" ]
   in
   let opams = [ Pkg.opam_file "opam" ~lint_deps_excluding ] in
   Pkg.describe ~opams "mirage-block-solo5" @@ fun c ->


### PR DESCRIPTION
I disagree with the proposed fix in https://github.com/mirage/mirage-block-solo5/commit/124d4a0698459caca8a510d9f874ec5192db5439 /cc @mato