### PR TITLE
Minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ env:
     global:
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.06
+        - OCAML_VERSION=4.05
+        - OCAML_VERSION=4.04
         - OCAML_VERSION=4.03
-        - OCAML_VERSION=4.02

--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
 true: annot, bin_annot, safe_string
 true: warn(A-44)
 
-<src/*> : package(cstruct lwt mirage-block-lwt result fmt)
+<src/*> : package(cstruct lwt mirage-block-lwt fmt)

--- a/opam
+++ b/opam
@@ -19,5 +19,5 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-solo5"
   "fmt"
-  "result"
 ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Solo5 block driver implementation"
-requires = "cstruct lwt mirage-types"
+requires = "cstruct lwt mirage-block-lwt"
 archive(byte) = "mirage_block_solo5.cma"
 archive(native) = "mirage_block_solo5.cmxa"
 plugin(byte) = "mirage_block_solo5.cma"

--- a/src/block.ml
+++ b/src/block.ml
@@ -15,8 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt
-open Printf
 open Mirage_block
 
 type 'a io = 'a Lwt.t
@@ -49,42 +47,41 @@ external solo5_blk_write: int64 -> Cstruct.buffer -> int -> bool = "stub_blk_wri
 external solo5_blk_read: int64 -> Cstruct.buffer -> int -> bool = "stub_blk_read"
 
 let disconnect _id =
-  printf "Blkfront: disconnect not implement yet\n";
-  return_unit
+  Printf.printf "Blkfront: disconnect not implement yet\n";
+  Lwt.return_unit
 
 let connect name =
   let sector_size = solo5_blk_sector_size () in
   let size_sectors = solo5_blk_sectors () in
   let read_write = solo5_blk_rw () in
-  return ({ name; info = { sector_size; size_sectors; read_write } })
+  Lwt.return ({ name; info = { sector_size; size_sectors; read_write } })
 
 
 let do_write sector b =
-  return (solo5_blk_write sector b.Cstruct.buffer b.Cstruct.len)
+  Lwt.return (solo5_blk_write sector b.Cstruct.buffer b.Cstruct.len)
 
 let rec write x sector_start buffers = match buffers with
-    | [] -> return (Ok ())
+    | [] -> Lwt.return (Ok ())
     | b :: bs ->
        let new_start = Int64.(add sector_start (div (of_int (Cstruct.len b))
                                                     (of_int x.info.sector_size))) in
        Lwt.bind (do_write sector_start b)
                 (fun (result) -> match result with
-                                 | false -> return (Error `Write)
+                                 | false -> Lwt.return (Error `Write)
                                  | true -> write x new_start bs)
 
 let do_read sector b =
-  return (solo5_blk_read sector b.Cstruct.buffer b.Cstruct.len)
+  Lwt.return (solo5_blk_read sector b.Cstruct.buffer b.Cstruct.len)
 
 let rec read x sector_start pages = match pages with
-    | [] -> return (Ok())
+    | [] -> Lwt.return (Ok ())
     | b :: bs ->
        let new_start = Int64.(add sector_start (div (of_int (Cstruct.len b))
                                                     (of_int x.info.sector_size))) in
        Lwt.bind (do_read sector_start b)
                 (fun (result) -> match result with
-                                 | false -> return (Error `Read)
+                                 | false -> Lwt.return (Error `Read)
                                  | true -> read x new_start bs)
 
 
-let get_info t =
-  return t.info
+let get_info t = Lwt.return t.info

--- a/src/block.ml
+++ b/src/block.ml
@@ -17,7 +17,6 @@
 
 open Lwt
 open Printf
-open Result
 open Mirage_block
 
 type 'a io = 'a Lwt.t


### PR DESCRIPTION
drop 4.02 support, remove result dependency, minor cleanups

`result` was a dependency in `opam` and `_tags`, but missing from `META`. 