### PR TITLE
Switch to Solo5 master for developent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false
+        - EXTRA_REMOTES="git://github.com/Solo5/opam-solo5"
     matrix:
         - OCAML_VERSION=4.06
         - OCAML_VERSION=4.05
         - OCAML_VERSION=4.04
-        - OCAML_VERSION=4.03

--- a/opam
+++ b/opam
@@ -17,7 +17,8 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5"
+  "mirage-solo5" {>= "0.3.0"}
   "fmt"
+  "result"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.04.2" ]


### PR DESCRIPTION
- Use Solo5/opam-solo5 as EXTRA_REMOTES
- Restrict to OCaml 4.04.2 and newer
- Update OPAM metadata, Travis build matrix