### PR TITLE
Adapt to Solo5 API changes, refactor

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
-PKG cstruct lwt mirage-block-lwt result fmt
+PKG cstruct lwt mirage-block-lwt fmt
 S src
 B _build/**

--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
 true: annot, bin_annot, safe_string
-true: warn(A-44)
+true: warn(A-37-44)
 
 <src/*> : package(cstruct lwt mirage-block-lwt fmt)

--- a/_tags
+++ b/_tags
@@ -1,4 +1,3 @@
 true: annot, bin_annot, safe_string
-true: warn(A-37-44)
 
-<src/*> : package(cstruct lwt mirage-block-lwt fmt)
+<src/*> : package(cstruct lwt mirage-block-lwt mirage-solo5 fmt)

--- a/opam
+++ b/opam
@@ -19,6 +19,5 @@ depends: [
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-solo5" {>= "0.3.0"}
   "fmt"
-  "result"
 ]
 available: [ ocaml-version >= "4.04.2" ]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Solo5 block driver implementation"
-requires = "cstruct lwt mirage-block-lwt mirage-solo5"
+requires = "cstruct lwt mirage-block-lwt mirage-solo5 fmt"
 archive(byte) = "mirage_block_solo5.cma"
 archive(native) = "mirage_block_solo5.cmxa"
 plugin(byte) = "mirage_block_solo5.cma"

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Solo5 block driver implementation"
-requires = "cstruct lwt mirage-block-lwt"
+requires = "cstruct lwt mirage-block-lwt mirage-solo5"
 archive(byte) = "mirage_block_solo5.cma"
 archive(native) = "mirage_block_solo5.cmxa"
 plugin(byte) = "mirage_block_solo5.cma"

--- a/src/block.ml
+++ b/src/block.ml
@@ -1,6 +1,7 @@
 (*
  * Copyright (c) 2011 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2012 Citrix Systems Inc
+ * Copyright (c) 2018 Martin Lucina <martin@lucina.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/src/block.ml
+++ b/src/block.ml
@@ -19,69 +19,112 @@ open Mirage_block
 
 type 'a io = 'a Lwt.t
 
+type t = {
+  name: string;
+  info: Mirage_block.info;
+}
+
 type page_aligned_buffer = Cstruct.t
 
-type error = [ Mirage_block.error | `Read ]
+type error = [
+  | Mirage_block.error
+  | `Invalid_argument
+  | `Unspecified_error
+]
 
 let pp_error ppf = function
   | #Mirage_block.error as e -> Mirage_block.pp_error ppf e
-  | `Read -> Fmt.string ppf "solo5 blk write"
+  | `Invalid_argument      -> Fmt.string ppf "Invalid argument"
+  | `Unspecified_error     -> Fmt.string ppf "Unspecified error"
 
-
-type write_error = [ Mirage_block.write_error | `Write ]
+type write_error = [
+  | Mirage_block.write_error
+  | `Invalid_argument
+  | `Unspecified_error
+]
 
 let pp_write_error ppf = function
   | #Mirage_block.write_error as e -> Mirage_block.pp_write_error ppf e
-  | `Write -> Fmt.string ppf "solo5 blk read"
+  | `Invalid_argument      -> Fmt.string ppf "Invalid argument"
+  | `Unspecified_error     -> Fmt.string ppf "Unspecified error"
 
-type t = {
-    name: string;
-    info: Mirage_block.info;
-  }
+type solo5_block_info = {
+  capacity: int64;
+  block_size: int64;
+}
 
-external solo5_blk_sector_size: unit -> int = "stub_blk_sector_size"
-external solo5_blk_sectors: unit -> int64 = "stub_blk_sectors"
-external solo5_blk_rw: unit -> bool = "stub_blk_rw"
+type solo5_result =
+  | SOLO5_R_OK
+  | SOLO5_R_AGAIN
+  | SOLO5_R_EINVAL
+  | SOLO5_R_EUNSPEC
 
-external solo5_blk_write: int64 -> Cstruct.buffer -> int -> bool = "stub_blk_write"
-external solo5_blk_read: int64 -> Cstruct.buffer -> int -> bool = "stub_blk_read"
+external solo5_block_info:
+  unit -> solo5_block_info = "mirage_solo5_block_info"
+external solo5_block_read:
+  int64 -> Cstruct.buffer -> int -> solo5_result = "mirage_solo5_block_read"
+external solo5_block_write:
+  int64 -> Cstruct.buffer -> int -> solo5_result = "mirage_solo5_block_write"
 
 let disconnect _id =
-  Printf.printf "Blkfront: disconnect not implement yet\n";
+  (* not implemented *)
   Lwt.return_unit
 
 let connect name =
-  let sector_size = solo5_blk_sector_size () in
-  let size_sectors = solo5_blk_sectors () in
-  let read_write = solo5_blk_rw () in
+  let bi = solo5_block_info () in
+  let sector_size = Int64.to_int bi.block_size in
+  let size_sectors = (Int64.div bi.capacity bi.block_size) in
+  let read_write = true in
   Lwt.return ({ name; info = { sector_size; size_sectors; read_write } })
 
+(* XXX: also applies to read: unclear if mirage actually issues I/O requests
+ * that are >1 sector in size *per buffer*. mirage-skeleton device-usage/block
+ * does not exhibit this behaviour. in any case, this will be caught at the
+ * Solo5 layer and return an error back if it happens.
+ *)
 
-let do_write sector b =
-  Lwt.return (solo5_blk_write sector b.Cstruct.buffer b.Cstruct.len)
+let do_write1 offset b =
+  let r = match solo5_block_write offset b.Cstruct.buffer b.Cstruct.len with
+    | SOLO5_R_OK      -> Ok ()
+    | SOLO5_R_AGAIN   -> assert false
+    | SOLO5_R_EINVAL  -> Error `Invalid_argument
+    | SOLO5_R_EUNSPEC -> Error `Unspecified_error
+  in
+  Lwt.return r
 
-let rec write x sector_start buffers = match buffers with
-    | [] -> Lwt.return (Ok ())
-    | b :: bs ->
-       let new_start = Int64.(add sector_start (div (of_int (Cstruct.len b))
-                                                    (of_int x.info.sector_size))) in
-       Lwt.bind (do_write sector_start b)
-                (fun (result) -> match result with
-                                 | false -> Lwt.return (Error `Write)
-                                 | true -> write x new_start bs)
+let rec do_write offset buffers = match buffers with
+  | [] -> Lwt.return (Ok ())
+  | b :: bs ->
+     let new_offset = Int64.(add offset (of_int (Cstruct.len b))) in
+     Lwt.bind (do_write1 offset b)
+              (fun (result) -> match result with
+                               | Error e -> Lwt.return (Error e)
+                               | Ok () -> do_write new_offset bs)
 
-let do_read sector b =
-  Lwt.return (solo5_blk_read sector b.Cstruct.buffer b.Cstruct.len)
+let write x sector_start buffers =
+  let offset = Int64.(mul sector_start (of_int x.info.sector_size)) in
+  do_write offset buffers
 
-let rec read x sector_start pages = match pages with
-    | [] -> Lwt.return (Ok ())
-    | b :: bs ->
-       let new_start = Int64.(add sector_start (div (of_int (Cstruct.len b))
-                                                    (of_int x.info.sector_size))) in
-       Lwt.bind (do_read sector_start b)
-                (fun (result) -> match result with
-                                 | false -> Lwt.return (Error `Read)
-                                 | true -> read x new_start bs)
+let do_read1 offset b =
+  let r = match solo5_block_read offset b.Cstruct.buffer b.Cstruct.len with
+    | SOLO5_R_OK      -> Ok ()
+    | SOLO5_R_AGAIN   -> assert false
+    | SOLO5_R_EINVAL  -> Error `Invalid_argument
+    | SOLO5_R_EUNSPEC -> Error `Unspecified_error
+  in
+  Lwt.return r
 
+let rec do_read offset buffers = match buffers with
+  | [] -> Lwt.return (Ok ())
+  | b :: bs ->
+     let new_offset = Int64.(add offset (of_int (Cstruct.len b))) in
+     Lwt.bind (do_read1 offset b)
+              (fun (result) -> match result with
+                               | Error e -> Lwt.return (Error e)
+                               | Ok () -> do_read new_offset bs)
+
+let read x sector_start buffers =
+  let offset = Int64.(mul sector_start (of_int x.info.sector_size)) in
+  do_read offset buffers
 
 let get_info t = Lwt.return t.info

--- a/src/block.ml
+++ b/src/block.ml
@@ -16,6 +16,7 @@
  *)
 
 open Mirage_block
+open OS.Solo5
 
 type 'a io = 'a Lwt.t
 
@@ -52,12 +53,6 @@ type solo5_block_info = {
   capacity: int64;
   block_size: int64;
 }
-
-type solo5_result =
-  | SOLO5_R_OK
-  | SOLO5_R_AGAIN
-  | SOLO5_R_EINVAL
-  | SOLO5_R_EUNSPEC
 
 external solo5_block_info:
   unit -> solo5_block_info = "mirage_solo5_block_info"


### PR DESCRIPTION
This adapts to Solo5 API changes in Solo5/solo5#245,
mirage/mirage-solo5#27, and refactors the code removing several layers
of accumulated cruft.

A solo5_result type (mapping to the C enum solo5_result_t) and
associated error handling has been introduced. Where possible
Solo5-generated errors are passed further up the stack.

Unnecessary use of Lwt.catch has been removed on Hannes' advice.

Note that CI will not build until mirage/mirage-solo5#27 is merged. Tested manually against mirage-skeleton device-usage/block unikernel.