### PR TITLE
Migrate to OPAM 2

### DIFF
--- a/opam
+++ b/opam
@@ -1,9 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "martin@lucina.net"
 homepage:     "https://github.com/mirage/mirage-block-solo5"
-dev-repo:     "https://github.com/mirage/mirage-block-solo5.git"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
 bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
-authors:      "Dan Williams <djwllia@us.ibm.com>"
+authors:      ["Dan Williams" "Martin Lucina"]
 tags: [
   "org:mirage"
 ]
@@ -11,13 +11,16 @@ build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]
 depends: [
+  "ocaml" {>= "4.04.2"}
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.3.0"}
+  "mirage-solo5" {>= "0.3.0" & < "0.5.0"}
   "fmt"
 ]
-available: [ ocaml-version >= "4.04.2" ]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."


### PR DESCRIPTION
Also, add upper bounds for mirage-solo5 due to upcoming changes in the C
stubs.