### PR TITLE
Correctly use Cstruct buffer offset

### DIFF
--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.3.0" & < "0.5.0"}
+  "mirage-solo5" {>= "0.5.0" & < "0.6.0"}
   "fmt"
 ]
 synopsis: "Solo5 implementation of MirageOS block interface"

--- a/src/block.ml
+++ b/src/block.ml
@@ -58,9 +58,9 @@ type solo5_block_info = {
 external solo5_block_info:
   unit -> solo5_block_info = "mirage_solo5_block_info"
 external solo5_block_read:
-  int64 -> Cstruct.buffer -> int -> solo5_result = "mirage_solo5_block_read"
+  int64 -> Cstruct.buffer -> int -> int -> solo5_result = "mirage_solo5_block_read_2"
 external solo5_block_write:
-  int64 -> Cstruct.buffer -> int -> solo5_result = "mirage_solo5_block_write"
+  int64 -> Cstruct.buffer -> int -> int -> solo5_result = "mirage_solo5_block_write_2"
 
 let disconnect _id =
   (* not implemented *)
@@ -80,7 +80,7 @@ let connect name =
  *)
 
 let do_write1 offset b =
-  let r = match solo5_block_write offset b.Cstruct.buffer b.Cstruct.len with
+  let r = match solo5_block_write offset b.Cstruct.buffer b.Cstruct.off b.Cstruct.len with
     | SOLO5_R_OK      -> Ok ()
     | SOLO5_R_AGAIN   -> assert false
     | SOLO5_R_EINVAL  -> Error `Invalid_argument
@@ -102,7 +102,7 @@ let write x sector_start buffers =
   do_write offset buffers
 
 let do_read1 offset b =
-  let r = match solo5_block_read offset b.Cstruct.buffer b.Cstruct.len with
+  let r = match solo5_block_read offset b.Cstruct.buffer b.Cstruct.off b.Cstruct.len with
     | SOLO5_R_OK      -> Ok ()
     | SOLO5_R_AGAIN   -> assert false
     | SOLO5_R_EINVAL  -> Error `Invalid_argument


### PR DESCRIPTION
Top half of mirage/mirage-solo5#37

Cstruct buffers may be slices of larger buffers, in which case it is not
sufficient to just pass through the buffer and length; this adds an
additional argument to pass b.Cstruct.off down to the mirage-solo5
stubs.

(Bump mirage-solo5 dependency to >= 0.5.0 accordingly)