### PR TITLE
Update to new Solo5 "manifest"-style APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 dist: xenial
+addons:
+    apt:
+        packages:
+            - libseccomp-dev
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
     global:
         - TESTS=false PACKAGE=mirage-block-solo5
     matrix:
-        - OCAML_VERSION=4.09
-        - OCAML_VERSION=4.08
-        - OCAML_VERSION=4.07
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-genode"
+        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: c
-sudo: required
-dist: trusty
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+dist: xenial
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
     global:
-        - TESTS=false
+        - TESTS=false PACKAGE=mirage-block-solo5
     matrix:
-        - OCAML_VERSION=4.06
-        - OCAML_VERSION=4.05
-        - OCAML_VERSION=4.04
+        - OCAML_VERSION=4.09
+        - OCAML_VERSION=4.08
+        - OCAML_VERSION=4.07

--- a/mirage-block-solo5.opam
+++ b/mirage-block-solo5.opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block-lwt" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.5.0" & < "0.6.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "fmt"
 ]
 synopsis: "Solo5 implementation of MirageOS block interface"


### PR DESCRIPTION
This updates the block interface code to work with the new Solo5
"manifest"-style APIs with support for multiple devices.

Part of mirage/mirage#992.